### PR TITLE
Add user_id field to banking_subaccounts insert

### DIFF
--- a/supabase/functions/create-paystack-subaccount/index.ts
+++ b/supabase/functions/create-paystack-subaccount/index.ts
@@ -276,6 +276,7 @@ serve(async (req) => {
       const { data: subaccountData, error: subaccountError } = await supabase
         .from("banking_subaccounts")
         .insert({
+          user_id: user.id,
           business_name,
           email,
           bank_name,


### PR DESCRIPTION
Add user_id field to the banking_subaccounts table insert operation in the create-paystack-subaccount function.

The user_id is now included in the insert statement using the user.id value.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/43560ee1ccf04582823e667bd13ffe1d/vortex-studio)

👀 [Preview Link](https://43560ee1ccf04582823e667bd13ffe1d-vortex-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>43560ee1ccf04582823e667bd13ffe1d</projectId>-->
<!--<branchName>vortex-studio</branchName>-->