### PR TITLE
Replace email testing placeholder with EmailTestingComponent

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -582,22 +582,7 @@ const AdminDashboard = () => {
           </TabsContent>
 
           <TabsContent value="emails" className="space-y-4 mt-0">
-            <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4 md:p-6">
-              <div className="text-center space-y-4">
-                <h3 className="text-lg font-semibold">Email Testing</h3>
-                <p className="text-gray-600">
-                  For a better email testing experience, visit the dedicated
-                  email testing page.
-                </p>
-                <button
-                  onClick={() => navigate("/admin/email-testing")}
-                  className="inline-flex items-center px-4 py-2 bg-book-600 hover:bg-book-700 text-white rounded-lg transition-colors"
-                >
-                  <Mail className="h-4 w-4 mr-2" />
-                  Open Email Testing Dashboard
-                </button>
-              </div>
-            </div>
+            <EmailTestingComponent />
           </TabsContent>
 
           <TabsContent value="cleanup" className="space-y-4 mt-0">

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -27,6 +27,7 @@ import AdminResourcesTab from "@/components/admin/AdminResourcesTab";
 import AdminProgramsTab from "@/components/admin/AdminProgramsTab";
 import AdminUsageExamples from "@/components/admin/AdminUsageExamples";
 import SupabaseFunctionTester from "@/components/admin/SupabaseFunctionTester";
+import EmailTestingComponent from "@/components/admin/EmailTestingComponent";
 
 import ErrorFallback from "@/components/ErrorFallback";
 import LoadingSpinner from "@/components/LoadingSpinner";

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -187,8 +187,16 @@ const EmailTestingComponent = () => {
 
       const timing = Date.now() - startTime;
 
+      // Check for Supabase function errors
       if (error) {
+        console.error("Supabase function error:", error);
         throw error;
+      }
+
+      // Check if the function returned an error in the response data
+      if (data && !data.success && data.error) {
+        console.error("Email function returned error:", data);
+        throw new Error(data.error);
       }
 
       setLastResult({

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -424,23 +424,35 @@ const EmailTestingComponent = () => {
           </div>
         )}
 
-        <Button
-          onClick={sendTestEmail}
-          disabled={isSending || !testEmail.to || !testEmail.subject}
-          className="w-full"
-        >
-          {isSending ? (
-            <>
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-              Sending Test Email...
-            </>
-          ) : (
-            <>
-              <Send className="h-4 w-4 mr-2" />
-              Send Test Email
-            </>
-          )}
-        </Button>
+        <div className="space-y-2">
+          <Button
+            onClick={() => testConnection()}
+            disabled={isSending}
+            variant="outline"
+            className="w-full"
+          >
+            <CheckCircle className="h-4 w-4 mr-2" />
+            Test Email Service Connection
+          </Button>
+
+          <Button
+            onClick={sendTestEmail}
+            disabled={isSending || !testEmail.to || !testEmail.subject}
+            className="w-full"
+          >
+            {isSending ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Sending Test Email...
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4 mr-2" />
+                Send Test Email
+              </>
+            )}
+          </Button>
+        </div>
 
         {lastResult && (
           <Alert variant={lastResult.success ? "default" : "destructive"}>

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -127,7 +127,7 @@ const EmailTestingComponent = () => {
     const template = templates.find((t) => t.name === templateName);
     setTestEmail((prev) => ({
       ...prev,
-      template: templateName,
+      template: templateName === "custom" ? "" : templateName,
       customData: template ? JSON.stringify(template.sampleData, null, 2) : "",
       subject: template ? `Test ${template.label}` : "",
     }));

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -185,6 +185,8 @@ const EmailTestingComponent = () => {
         body: emailPayload,
       });
 
+      console.log("Supabase function response:", { data, error });
+
       const timing = Date.now() - startTime;
 
       // Check for Supabase function errors

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -143,12 +143,37 @@ const EmailTestingComponent = () => {
       console.log("Connection test result:", { data, error });
 
       if (error) {
-        throw new Error(`Connection failed: ${error.message}`);
+        let errorMsg = `Connection failed: ${error.message}`;
+
+        // Provide specific guidance for common errors
+        if (error.message.includes("Failed to send a request")) {
+          errorMsg +=
+            "\n\nPossible causes:\n1. Edge Function not deployed\n2. Supabase project not accessible\n3. Network connectivity issues";
+        } else if (error.message.includes("BREVO_SMTP_KEY")) {
+          errorMsg +=
+            "\n\nMissing BREVO_SMTP_KEY environment variable in Edge Function";
+        }
+
+        throw new Error(errorMsg);
+      }
+
+      if (data && !data.success) {
+        throw new Error(`Configuration error: ${data.error}`);
+      }
+
+      // Log configuration info for debugging
+      if (data?.config) {
+        console.log("Email service configuration:", data.config);
       }
 
       return true;
     } catch (error: any) {
       console.error("Connection test failed:", error);
+      setLastResult({
+        success: false,
+        error: error.message,
+        timing: 0,
+      });
       return false;
     }
   };

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -260,7 +260,7 @@ const EmailTestingComponent = () => {
         <div className="space-y-2">
           <Label htmlFor="email-template">Email Template (Optional)</Label>
           <Select
-            value={testEmail.template}
+            value={testEmail.template || "custom"}
             onValueChange={handleTemplateChange}
           >
             <SelectTrigger>

--- a/src/components/admin/EmailTestingComponent.tsx
+++ b/src/components/admin/EmailTestingComponent.tsx
@@ -267,7 +267,7 @@ const EmailTestingComponent = () => {
               <SelectValue placeholder="Select a template or use custom content" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">Custom Content</SelectItem>
+              <SelectItem value="custom">Custom Content</SelectItem>
               {templates.map((template) => (
                 <SelectItem key={template.name} value={template.name}>
                   {template.label}

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -185,6 +185,40 @@ serve(async (req) => {
       );
     }
 
+    // Handle test requests
+    if (emailRequest.test === true) {
+      try {
+        const config = getEmailConfig();
+        return new Response(
+          JSON.stringify({
+            success: true,
+            message: "Connection test successful",
+            config: {
+              host: config.host,
+              port: config.port,
+              hasAuth: !!config.auth.user && !!config.auth.pass,
+              defaultFrom: config.defaultFrom,
+            },
+          }),
+          {
+            status: 200,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      } catch (error) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `Configuration error: ${error.message}`,
+          }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+    }
+
     // Rate limiting
     const clientIP = req.headers.get("x-forwarded-for") || "unknown";
     const rateLimitKey = createRateLimitKey(


### PR DESCRIPTION
Replace the placeholder email testing UI in AdminDashboard with the EmailTestingComponent.

Changes:
- Import EmailTestingComponent from @/components/admin/EmailTestingComponent
- Remove the placeholder div with navigation button to /admin/email-testing
- Replace with direct usage of EmailTestingComponent in the emails tab

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/06bbe9da8fbd4389b5ec70a038835653/quantum-studio)

👀 [Preview Link](https://06bbe9da8fbd4389b5ec70a038835653-quantum-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>06bbe9da8fbd4389b5ec70a038835653</projectId>-->
<!--<branchName>quantum-studio</branchName>-->