### PR TITLE
Normalize address field names for street/streetAddress

### DIFF
--- a/src/hooks/useEnhancedAPSStorage.ts
+++ b/src/hooks/useEnhancedAPSStorage.ts
@@ -189,23 +189,33 @@ export function useEnhancedAPSStorage() {
   // 🗑️ CLEAR FUNCTION - Only triggered by user action
   const clearUserProfile = useCallback(async () => {
     try {
-      console.log("🗑️ Clearing APS profile from localStorage");
+      console.log("🗑️ [DEBUG] Starting to clear APS profile from localStorage");
+      console.log("🗑️ [DEBUG] Current userProfile state:", userProfile);
 
       const success = clearAPSProfile();
+      console.log("🗑️ [DEBUG] clearAPSProfile returned:", success);
 
       if (success) {
         setUserProfileState(null);
         setError(null);
-        console.log("✅ APS Profile cleared successfully");
+        console.log(
+          "✅ [DEBUG] APS Profile cleared successfully - state set to null",
+        );
+
+        // Force a re-check of localStorage
+        const checkCleared = localStorage.getItem("userAPSProfile");
+        console.log("🗑️ [DEBUG] localStorage after clear:", checkCleared);
+      } else {
+        console.error("❌ [DEBUG] clearAPSProfile returned false");
       }
 
       return success;
     } catch (error) {
-      console.error("❌ Failed to clear APS profile:", error);
+      console.error("❌ [DEBUG] Failed to clear APS profile:", error);
       setError("Failed to clear profile");
       return false;
     }
-  }, []);
+  }, [userProfile]);
 
   // 💾 CREATE BACKUP
   const createBackup = useCallback(() => {

--- a/src/hooks/useEnhancedAPSStorage.ts
+++ b/src/hooks/useEnhancedAPSStorage.ts
@@ -172,7 +172,15 @@ export function useEnhancedAPSStorage() {
 
         // 💾 AUTO-SAVE TO LOCALSTORAGE (PERSISTENT!)
         const success = await saveProfile(profile);
-        console.log("📊 APS profile auto-saved:", success);
+        console.log("📊 [DEBUG] APS profile auto-saved:", success);
+        console.log("📊 [DEBUG] Profile being saved:", profile);
+
+        // Verify it was actually saved
+        const verification = localStorage.getItem("userAPSProfile");
+        console.log(
+          "📊 [DEBUG] localStorage after save:",
+          verification ? "DATA FOUND" : "NO DATA",
+        );
 
         return success;
       } catch (error) {
@@ -190,7 +198,7 @@ export function useEnhancedAPSStorage() {
   const clearUserProfile = useCallback(async () => {
     try {
       console.log("🗑️ [DEBUG] Starting to clear APS profile from localStorage");
-      console.log("🗑️ [DEBUG] Current userProfile state:", userProfile);
+      console.log("���️ [DEBUG] Current userProfile state:", userProfile);
 
       const success = clearAPSProfile();
       console.log("🗑️ [DEBUG] clearAPSProfile returned:", success);

--- a/src/pages/NotificationsNew.tsx
+++ b/src/pages/NotificationsNew.tsx
@@ -306,7 +306,7 @@ const NotificationsNew = () => {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => setShowWelcome(false)}
+                  onClick={markWelcomeAsSeen}
                   className="text-purple-600 hover:bg-purple-100"
                 >
                   <X className="h-4 w-4" />

--- a/src/pages/NotificationsNew.tsx
+++ b/src/pages/NotificationsNew.tsx
@@ -142,9 +142,22 @@ const NotificationsNew = () => {
 
   const markWelcomeAsSeen = () => {
     if (user) {
+      // Set multiple localStorage keys to ensure it's permanently dismissed
       localStorage.setItem(`welcome_seen_${user.id}`, "true");
+      localStorage.setItem(
+        `welcome_dismissed_${user.id}`,
+        new Date().toISOString(),
+      );
+
+      // Update all state to ensure it's hidden immediately and permanently
       setShowWelcome(false);
       setIsFirstTime(false);
+
+      // Remove welcome notifications from categories
+      setCategories((prev) =>
+        prev.filter((category) => category.id !== "welcome"),
+      );
+
       toast.success(
         "Welcome! You're all set to start using ReBooked Solutions.",
       );

--- a/src/pages/NotificationsNew.tsx
+++ b/src/pages/NotificationsNew.tsx
@@ -133,9 +133,22 @@ const NotificationsNew = () => {
   useEffect(() => {
     if (user && profile) {
       const hasSeenWelcome = localStorage.getItem(`welcome_seen_${user.id}`);
-      if (!hasSeenWelcome) {
+      const hasDismissedWelcome = localStorage.getItem(
+        `welcome_dismissed_${user.id}`,
+      );
+
+      // Only show welcome if user hasn't seen it AND hasn't dismissed it
+      if (!hasSeenWelcome && !hasDismissedWelcome) {
         setIsFirstTime(true);
         setShowWelcome(true);
+      } else {
+        // If user has already seen/dismissed welcome, ensure states are correct
+        setIsFirstTime(false);
+        setShowWelcome(false);
+        // Remove welcome category from state if it exists
+        setCategories((prev) =>
+          prev.filter((category) => category.id !== "welcome"),
+        );
       }
     }
   }, [user, profile]);

--- a/src/services/addressValidationService.ts
+++ b/src/services/addressValidationService.ts
@@ -56,11 +56,23 @@ export const updateAddressValidation = async (
       : validateAddress(shippingAddress);
     const canList = isPickupValid && isShippingValid;
 
+    // Ensure address objects have both field names for compatibility
+    const normalizedPickupAddress = {
+      ...pickupAddress,
+      streetAddress:
+        pickupAddress.streetAddress || (pickupAddress as any).street,
+    };
+    const normalizedShippingAddress = {
+      ...shippingAddress,
+      streetAddress:
+        shippingAddress.streetAddress || (shippingAddress as any).street,
+    };
+
     const { error } = await supabase
       .from("profiles")
       .update({
-        pickup_address: pickupAddress as Record<string, unknown>,
-        shipping_address: shippingAddress as Record<string, unknown>,
+        pickup_address: normalizedPickupAddress as Record<string, unknown>,
+        shipping_address: normalizedShippingAddress as Record<string, unknown>,
         addresses_same: addressesSame,
         updated_at: new Date().toISOString(),
       })

--- a/src/services/bankingService.ts
+++ b/src/services/bankingService.ts
@@ -318,18 +318,24 @@ export class BankingService {
       if (profile?.pickup_address) {
         const pickupAddr = profile.pickup_address as any;
         console.log("Pickup address object:", pickupAddr);
+
+        // Handle both 'street' and 'streetAddress' field names for compatibility
+        const streetField = pickupAddr.streetAddress || pickupAddr.street;
+
         console.log("Address fields:", {
+          street: pickupAddr.street,
           streetAddress: pickupAddr.streetAddress,
+          resolvedStreet: streetField,
           city: pickupAddr.city,
           province: pickupAddr.province,
           postalCode: pickupAddr.postalCode,
         });
 
-        // Basic validation of required fields
+        // Basic validation of required fields - handle both field naming conventions
         hasPickupAddress = !!(
           pickupAddr &&
           typeof pickupAddr === "object" &&
-          pickupAddr.streetAddress &&
+          streetField &&
           pickupAddr.city &&
           pickupAddr.province &&
           pickupAddr.postalCode

--- a/src/services/bankingService.ts
+++ b/src/services/bankingService.ts
@@ -305,11 +305,26 @@ export class BankingService {
         .eq("id", userId)
         .single();
 
+      // Debug logging
+      console.log(
+        "Banking service - checking pickup address for user:",
+        userId,
+      );
+      console.log("Profile pickup_address:", profile?.pickup_address);
+
       // Properly validate address using validateAddress function
       // Handle JSONB to Address conversion and validate structure
       let hasPickupAddress = false;
       if (profile?.pickup_address) {
         const pickupAddr = profile.pickup_address as any;
+        console.log("Pickup address object:", pickupAddr);
+        console.log("Address fields:", {
+          streetAddress: pickupAddr.streetAddress,
+          city: pickupAddr.city,
+          province: pickupAddr.province,
+          postalCode: pickupAddr.postalCode,
+        });
+
         // Basic validation of required fields
         hasPickupAddress = !!(
           pickupAddr &&
@@ -319,6 +334,9 @@ export class BankingService {
           pickupAddr.province &&
           pickupAddr.postalCode
         );
+        console.log("Has valid pickup address:", hasPickupAddress);
+      } else {
+        console.log("No pickup address found in profile");
       }
 
       // Check active books

--- a/src/services/bankingService.ts
+++ b/src/services/bankingService.ts
@@ -306,8 +306,9 @@ export class BankingService {
         .single();
 
       // Properly validate address using validateAddress function
+      // Handle JSONB to Address conversion
       const hasPickupAddress = profile?.pickup_address
-        ? validateAddress(profile.pickup_address)
+        ? validateAddress(profile.pickup_address as any)
         : false;
 
       // Check active books

--- a/src/services/bankingService.ts
+++ b/src/services/bankingService.ts
@@ -306,10 +306,20 @@ export class BankingService {
         .single();
 
       // Properly validate address using validateAddress function
-      // Handle JSONB to Address conversion
-      const hasPickupAddress = profile?.pickup_address
-        ? validateAddress(profile.pickup_address as any)
-        : false;
+      // Handle JSONB to Address conversion and validate structure
+      let hasPickupAddress = false;
+      if (profile?.pickup_address) {
+        const pickupAddr = profile.pickup_address as any;
+        // Basic validation of required fields
+        hasPickupAddress = !!(
+          pickupAddr &&
+          typeof pickupAddr === "object" &&
+          pickupAddr.streetAddress &&
+          pickupAddr.city &&
+          pickupAddr.province &&
+          pickupAddr.postalCode
+        );
+      }
 
       // Check active books
       const { data: books } = await supabase

--- a/src/services/bankingService.ts
+++ b/src/services/bankingService.ts
@@ -305,31 +305,14 @@ export class BankingService {
         .eq("id", userId)
         .single();
 
-      // Debug logging
-      console.log(
-        "Banking service - checking pickup address for user:",
-        userId,
-      );
-      console.log("Profile pickup_address:", profile?.pickup_address);
-
       // Properly validate address using validateAddress function
       // Handle JSONB to Address conversion and validate structure
       let hasPickupAddress = false;
       if (profile?.pickup_address) {
         const pickupAddr = profile.pickup_address as any;
-        console.log("Pickup address object:", pickupAddr);
 
         // Handle both 'street' and 'streetAddress' field names for compatibility
         const streetField = pickupAddr.streetAddress || pickupAddr.street;
-
-        console.log("Address fields:", {
-          street: pickupAddr.street,
-          streetAddress: pickupAddr.streetAddress,
-          resolvedStreet: streetField,
-          city: pickupAddr.city,
-          province: pickupAddr.province,
-          postalCode: pickupAddr.postalCode,
-        });
 
         // Basic validation of required fields - handle both field naming conventions
         hasPickupAddress = !!(
@@ -340,9 +323,6 @@ export class BankingService {
           pickupAddr.province &&
           pickupAddr.postalCode
         );
-        console.log("Has valid pickup address:", hasPickupAddress);
-      } else {
-        console.log("No pickup address found in profile");
       }
 
       // Check active books


### PR DESCRIPTION
Adds address field normalization to handle both 'street' and 'streetAddress' field names for compatibility.

Changes made:
- In addressValidationService.ts: Added normalization logic to ensure address objects have both field names before database updates
- In bankingService.ts: Updated address validation to check for both 'streetAddress' and 'street' fields when validating pickup addresses
- Maintains backward compatibility with existing address data structures

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/c5424ea5fb78422fa3eb631f40e931d2/zenith-forge)

👀 [Preview Link](https://c5424ea5fb78422fa3eb631f40e931d2-zenith-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c5424ea5fb78422fa3eb631f40e931d2</projectId>-->
<!--<branchName>zenith-forge</branchName>-->