### PR TITLE
Remove "Grade" prefix from grade badge display

### DIFF
--- a/src/components/home/FeaturedBooks.tsx
+++ b/src/components/home/FeaturedBooks.tsx
@@ -141,7 +141,7 @@ const FeaturedBookCard = ({ book }: { book: Book }) => {
             </Badge>
             {book.grade && (
               <Badge variant="secondary" className="text-xs">
-                Grade {book.grade}
+                {book.grade}
               </Badge>
             )}
           </div>


### PR DESCRIPTION
Remove the "Grade" text prefix from the grade badge in FeaturedBookCard component.

The badge now displays only the grade value instead of "Grade {value}".

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/b3eccdd659fd4dabbf6a13ce7ea0755a/orbit-studio)

👀 [Preview Link](https://b3eccdd659fd4dabbf6a13ce7ea0755a-orbit-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b3eccdd659fd4dabbf6a13ce7ea0755a</projectId>-->
<!--<branchName>orbit-studio</branchName>-->