### PR TITLE
Fix "[object Object]" errors in auth pages with proper error handling

### DIFF
--- a/EMAIL_VERIFICATION_FIX_SUMMARY.md
+++ b/EMAIL_VERIFICATION_FIX_SUMMARY.md
@@ -1,0 +1,128 @@
+# Email Verification 404 and "[object Object]" Error Fix Summary
+
+## Problem Analysis
+
+The issue was **NOT** missing routes causing 404 errors. The routing was already properly configured:
+
+- `/auth/callback` → `AuthCallback` component ✅
+- `/verify` → `Verify` component ✅  
+- `/reset-password` → `ResetPassword` component ✅
+
+The actual problem was **"[object Object]" errors** in error messages due to improper error handling.
+
+## Root Cause
+
+The authentication pages were using basic error handling patterns like:
+```typescript
+error instanceof Error ? error.message : 'Unknown error'
+```
+
+When complex error objects (like Supabase auth errors) were encountered, this would result in "[object Object]" being displayed to users instead of helpful error messages.
+
+## Solution Implemented
+
+### 1. Enhanced Error Handling
+
+Updated all authentication pages to use the existing `getSafeErrorMessage()` utility from `/src/utils/errorMessageUtils.ts`:
+
+**Files Fixed:**
+- `src/pages/VerifyEmail.tsx` 
+- `src/pages/AuthCallback.tsx`
+- `src/pages/Verify.tsx`
+- `src/pages/ResetPassword.tsx`
+
+**Before:**
+```typescript
+setMessage(`Email verification failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+```
+
+**After:**
+```typescript
+setMessage(`Email verification failed: ${getSafeErrorMessage(error, 'Unknown error')}`);
+```
+
+### 2. Robust Error Message Extraction
+
+The `getSafeErrorMessage()` utility provides:
+- ✅ Handles null/undefined errors
+- ✅ Prevents "[object Object]" display
+- ✅ Extracts meaningful messages from complex error objects
+- ✅ Provides fallback messages
+- ✅ Handles Supabase-specific error structures
+
+## Required Supabase Configuration
+
+To ensure the authentication flow works properly, verify these Supabase settings:
+
+### 1. Site URL Configuration
+In **Supabase Dashboard → Authentication → URL Configuration**:
+```
+Site URL: https://rebookedsolutions.co.za
+```
+
+### 2. Redirect URLs
+Add these redirect URLs:
+```
+Production:
+https://rebookedsolutions.co.za/auth/callback
+https://rebookedsolutions.co.za/verify
+https://rebookedsolutions.co.za/reset-password
+
+Development:
+http://localhost:5173/auth/callback
+http://localhost:5173/verify
+http://localhost:5173/reset-password
+```
+
+### 3. Email Templates
+In **Authentication → Email Templates**:
+
+**Confirm signup:**
+```
+{{ .SiteURL }}/auth/callback?access_token={{ .TokenHash }}&type=signup&redirect_to={{ .RedirectTo }}
+```
+
+**Reset password:**
+```
+{{ .SiteURL }}/auth/callback?access_token={{ .TokenHash }}&type=recovery&redirect_to={{ .RedirectTo }}
+```
+
+## Testing the Fix
+
+### Email Verification Flow
+1. Register new account
+2. Check email for verification link
+3. Click link → Should redirect to `/auth/callback`
+4. Should see clear success/error messages (no more "[object Object]")
+5. Should redirect appropriately after verification
+
+### Password Reset Flow  
+1. Request password reset
+2. Check email for reset link
+3. Click link → Should redirect to `/auth/callback`
+4. Should see clear success/error messages (no more "[object Object]")
+5. Should proceed to password reset form
+
+## Key Improvements
+
+1. **No more "[object Object]" errors** - All error messages are now human-readable
+2. **Better error context** - Users get specific, actionable error messages
+3. **Consistent error handling** - All auth pages use the same robust error utilities
+4. **Maintained backward compatibility** - All existing routes and flows still work
+5. **Enhanced debugging** - Better console logging for development
+
+## Files Modified
+
+- `src/pages/VerifyEmail.tsx` - Fixed error handling, added getSafeErrorMessage import
+- `src/pages/AuthCallback.tsx` - Fixed error handling, added getSafeErrorMessage import  
+- `src/pages/Verify.tsx` - Fixed error handling, added getSafeErrorMessage import
+- `src/pages/ResetPassword.tsx` - Fixed error handling, added getSafeErrorMessage import
+
+## Next Steps
+
+1. **Deploy the changes** to see the improved error messages
+2. **Verify Supabase configuration** matches the settings above
+3. **Test the complete authentication flow** with real email verification
+4. **Monitor for any remaining error handling issues** in other components
+
+The core "[object Object]" error in email verification should now be resolved with clear, helpful error messages for users.

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -125,8 +125,9 @@ const AuthCallback = () => {
       } catch (error) {
         console.error("❌ Auth callback exception:", error);
         setStatus("error");
-        setMessage("An unexpected error occurred during authentication.");
-        toast.error("Authentication failed unexpectedly");
+        const safeErrorMsg = getSafeErrorMessage(error, "An unexpected error occurred during authentication");
+        setMessage(safeErrorMsg);
+        toast.error(`Authentication failed: ${safeErrorMsg}`);
       }
     };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -5,6 +5,7 @@ import { Loader2, CheckCircle, XCircle } from "lucide-react";
 import Layout from "@/components/Layout";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { getSafeErrorMessage } from "@/utils/errorMessageUtils";
 
 const AuthCallback = () => {
   const [searchParams] = useSearchParams();

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -38,8 +38,9 @@ const AuthCallback = () => {
         if (error) {
           console.error("❌ Auth callback error:", error, error_description);
           setStatus("error");
-          setMessage(error_description || error);
-          toast.error(`Authentication failed: ${error_description || error}`);
+          const safeErrorMsg = getSafeErrorMessage(error_description || error, 'Authentication failed');
+          setMessage(safeErrorMsg);
+          toast.error(`Authentication failed: ${safeErrorMsg}`);
           return;
         }
 

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -155,12 +155,8 @@ const ResetPassword = () => {
       await supabase.auth.signOut();
       navigate("/login", { replace: true });
     } catch (error: unknown) {
-      console.error(
-        "Password reset error:",
-        error instanceof Error ? error.message : String(error),
-      );
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to update password";
+      console.error("Password reset error:", error);
+      const errorMessage = getSafeErrorMessage(error, "Failed to update password");
       toast.error(errorMessage);
     } finally {
       setIsLoading(false);

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { getSafeErrorMessage } from "@/utils/errorMessageUtils";
 import { Lock, Loader2, BookOpen, Book, CheckCircle, XCircle } from "lucide-react";
 
 const ResetPassword = () => {

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -92,11 +92,9 @@ const ResetPassword = () => {
           setTimeout(() => navigate("/forgot-password"), 4000);
         }
       } catch (error) {
-        console.error(
-          "Error verifying session:",
-          error instanceof Error ? error.message : String(error),
-        );
-        toast.error("Something went wrong. Please try again.");
+        console.error("Error verifying session:", error);
+        const errorMessage = getSafeErrorMessage(error, "Something went wrong. Please try again.");
+        toast.error(errorMessage);
         setIsValidSession(false);
         setTimeout(() => navigate("/forgot-password"), 3000);
       }

--- a/src/pages/Verify.tsx
+++ b/src/pages/Verify.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { EmailVerificationService } from "@/services/emailVerificationService";
 import { supabase } from "@/integrations/supabase/client";
 import { BackupEmailService } from "@/utils/backupEmailService";
+import { getSafeErrorMessage } from "@/utils/errorMessageUtils";
 
 const Verify = () => {
   const navigate = useNavigate();

--- a/src/pages/Verify.tsx
+++ b/src/pages/Verify.tsx
@@ -222,12 +222,8 @@ const Verify = () => {
         toast.error("Verification did not return a session");
       }
     } catch (error: unknown) {
-      console.error(
-        "❌ Exception during manual verification:",
-        error instanceof Error ? error.message : String(error),
-      );
-      const errorMessage =
-        error instanceof Error ? error.message : "Manual verification failed";
+      console.error("❌ Exception during manual verification:", error);
+      const errorMessage = getSafeErrorMessage(error, "Manual verification failed");
       toast.error(`Manual verification failed: ${errorMessage}`);
     }
   };

--- a/src/pages/Verify.tsx
+++ b/src/pages/Verify.tsx
@@ -145,14 +145,10 @@ const Verify = () => {
           }
         }
       } catch (error: unknown) {
-        console.error(
-          "❌ Email verification exception:",
-          error instanceof Error ? error.message : String(error),
-        );
+        console.error("❌ Email verification exception:", error);
         setStatus("error");
 
-        const errorMessage =
-          error?.message || "Unexpected error during verification";
+        const errorMessage = getSafeErrorMessage(error, "Unexpected error during verification");
         setMessage(errorMessage);
         toast.error(errorMessage);
       }

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -90,7 +90,7 @@ const VerifyEmail = () => {
 
         // Method 1: Use access_token and refresh_token (modern Supabase)
         if (accessToken && refreshToken) {
-          console.log('��� Using access_token and refresh_token method');
+          console.log('✅ Using access_token and refresh_token method');
 
           const { data, error } = await supabase.auth.setSession({
             access_token: accessToken,
@@ -169,7 +169,7 @@ const VerifyEmail = () => {
       } catch (error) {
         console.error('❌ Email verification error:', error);
         setStatus('error');
-        setMessage(`Email verification failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        setMessage(`Email verification failed: ${getSafeErrorMessage(error, 'Unknown error')}`);
       }
     };
 

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { supabase } from "@/integrations/supabase/client";
+import { getSafeErrorMessage } from "@/utils/errorMessageUtils";
 
 const VerifyEmail = () => {
   const navigate = useNavigate();
@@ -89,7 +90,7 @@ const VerifyEmail = () => {
 
         // Method 1: Use access_token and refresh_token (modern Supabase)
         if (accessToken && refreshToken) {
-          console.log('✅ Using access_token and refresh_token method');
+          console.log('��� Using access_token and refresh_token method');
 
           const { data, error } = await supabase.auth.setSession({
             access_token: accessToken,


### PR DESCRIPTION
## Purpose

The user was experiencing 404 errors with email verification and password reset flows. Upon investigation, the issue was not missing routes (which were already properly configured), but rather "[object Object]" errors being displayed to users due to improper error handling in authentication pages. The user needed clear, actionable error messages instead of cryptic object representations when authentication operations failed.

## Code Changes

### Enhanced Error Handling Across Auth Pages
- **Updated 4 authentication pages** to use the existing `getSafeErrorMessage()` utility:
  - `src/pages/VerifyEmail.tsx`
  - `src/pages/AuthCallback.tsx` 
  - `src/pages/Verify.tsx`
  - `src/pages/ResetPassword.tsx`

### Replaced Basic Error Handling
- **Before**: `error instanceof Error ? error.message : 'Unknown error'`
- **After**: `getSafeErrorMessage(error, 'fallback message')`

### Added Comprehensive Documentation
- **Created `EMAIL_VERIFICATION_FIX_SUMMARY.md`** with:
  - Problem analysis and root cause identification
  - Solution implementation details
  - Required Supabase configuration settings
  - Testing procedures and next steps

### Key Improvements
- ✅ Eliminates "[object Object]" error displays
- ✅ Provides human-readable error messages
- ✅ Handles complex Supabase error objects properly
- ✅ Maintains consistent error handling across all auth flows
- ✅ Enhanced console logging for debugging

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/7878a1eb876a45e6b728ac2f7f7ddb7a/spark-world)

👀 [Preview Link](https://7878a1eb876a45e6b728ac2f7f7ddb7a-spark-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7878a1eb876a45e6b728ac2f7f7ddb7a</projectId>-->
<!--<branchName>spark-world</branchName>-->