### PR TITLE
Fix auth callback redirect for already logged in users

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -6,6 +6,7 @@ import Layout from "@/components/Layout";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { getSafeErrorMessage } from "@/utils/errorMessageUtils";
+import { useAuth } from "@/contexts/AuthContext";
 
 const AuthCallback = () => {
   const [searchParams] = useSearchParams();

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -235,7 +235,7 @@ const AuthCallback = () => {
     };
 
     handleAuthCallback();
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, authLoading, isAuthenticated]);
 
   const handleRetry = () => {
     navigate("/login", { replace: true });

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -11,10 +11,25 @@ import { useAuth } from "@/contexts/AuthContext";
 const AuthCallback = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [message, setMessage] = useState("");
 
+  // Check if user is already authenticated and redirect them
   useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      console.log("🔄 User already authenticated, redirecting from auth callback");
+      toast.success("You are already logged in!");
+      navigate("/", { replace: true });
+      return;
+    }
+  }, [isAuthenticated, authLoading, navigate]);
+
+  useEffect(() => {
+    // Don't process auth callback if user is already authenticated or auth is still loading
+    if (authLoading || isAuthenticated) {
+      return;
+    }
     const handleAuthCallback = async () => {
       try {
         console.log("🔍 Processing auth callback");


### PR DESCRIPTION
## Purpose
Fix an issue where users who are already logged in would still see the auth callback page when clicking "try alternative verification" instead of being properly redirected. The user reported being already logged in but still landing on the auth callback page.

## Code changes
- Added authentication state check using `useAuth` hook in `AuthCallback.tsx`
- Added early redirect logic to immediately redirect authenticated users to home page with success toast
- Added guard clause to prevent auth callback processing when user is already authenticated or auth is still loading
- Updated useEffect dependencies to include `authLoading` and `isAuthenticated`
- Added console logging for debugging authenticated user redirects

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/4eff2a72601c4d64abda6c10e090581b/zen-zone)

👀 [Preview Link](https://4eff2a72601c4d64abda6c10e090581b-zen-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4eff2a72601c4d64abda6c10e090581b</projectId>-->
<!--<branchName>zen-zone</branchName>-->